### PR TITLE
ci: publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
     name: node ${{ matrix.node-version }} / homebridge ${{ matrix.homebridge-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to NPM
 on:
   release: # Run when release is created
     types: [created]
+  workflow_dispatch: # allow re-running the publish without recreating the release
 
 jobs:
   build:
@@ -19,10 +20,10 @@ jobs:
     name: node ${{ matrix.node-version }} / homebridge ${{ matrix.homebridge-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -44,20 +45,25 @@ jobs:
           CI: true
 
   publish-npm:
-    # publish only if we are on our own repo, event was 'release' (a tag was created) and the tag starts with "v" (aka version tag)
-    if: github.repository == 'kovalev-sergey/homebridge-sony-audio' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+    # publish only if we are on our own repo and either a version tag was released or the workflow was run manually
+    if: github.repository == 'kovalev-sergey/homebridge-sony-audio' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')))
 
     needs: build # only run if build succeeds
 
     runs-on: ubuntu-latest
 
+    # npm trusted publishing (OIDC): no long lived NPM_TOKEN, provenance is attached automatically
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22 # use the minimum required version
           registry-url: https://registry.npmjs.org/
+      - name: Upgrade npm # trusted publishing requires npm >= 11.5.1
+        run: npm install -g npm@latest
       - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+      - run: npm publish # authenticated through OIDC, no NODE_AUTH_TOKEN

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,12 @@ The `SonyDevice` instance is stored in `PlatformAccessory<SonyDevice>.context`.
 1. Bump `version` in `package.json` (+ lock file) and commit as `chore: version bump`.
 2. Merge to `master`; `Build and Lint` workflow must be green.
 3. Create a GitHub **release** with a tag `vX.Y.Z` (tags in repo: `v1.0.8` … `v1.2.0`).
-4. `.github/workflows/publish.yml` triggers on release creation: it re-runs lint+build on
-   Node 22/24 against both Homebridge majors, then `npm publish` to npm using the `npm_token`
-   secret. Publishing is gated on repo == `kovalev-sergey/homebridge-sony-audio` and a `v*` tag.
+4. `.github/workflows/publish.yml` triggers on release creation (or `workflow_dispatch`):
+   it re-runs lint+build on Node 22/24 against both Homebridge majors, then `npm publish`
+   to npm. Authentication uses **npm trusted publishing (OIDC)** — the job requests
+   `id-token: write` and needs npm >= 11.5.1, there is no `NPM_TOKEN` secret, and npm
+   attaches build provenance automatically. Publishing is gated on
+   repo == `kovalev-sergey/homebridge-sony-audio` and a `v*` tag.
 5. `prepublishOnly` runs `lint` + `test` + `build` locally as a safety net; `.npmignore` keeps `src/`,
    tests and dev config out of the published tarball (`dist/` is what ships).
 


### PR DESCRIPTION
Switches the npm publish step to npm trusted publishing (OIDC), now that the trusted publisher is configured on npmjs.com.

- `permissions: id-token: write` on `publish-npm`; `NODE_AUTH_TOKEN` / the `NPM_TOKEN` secret is gone (a present token would take precedence over OIDC).
- `npm install -g npm@latest` in the publish job — trusted publishing requires npm >= 11.5.1 and setup-node's Node 22 ships npm 10.x.
- Added a `workflow_dispatch` trigger so a failed publish can be retried without deleting and recreating the release.
- Bumped `actions/checkout` and `actions/setup-node` to v5, clearing the Node 20 deprecation warnings.

Provenance will now be attached to the published package automatically.