### PR TITLE
fix: api version negotiation, single hap callback, input name persistence

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,14 @@
 src
 docs
 
+# AI agent instructions
+AGENTS.md
+CLAUDE.md
+.pi
+.claude
+.cursor
+.github/copilot-instructions.md
+
 # ------------- Defaults ------------- #
 
 # gitHub actions

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The following Sony audio products are accessible via the Homebridge Sony Audio P
 |HT-ZF9|3.1 channel Dolby Atmos/DTS:X soundbar with Wi-Fi/Bluetooth technology|<a href="https://www.sony.co.uk/electronics/sound-bars/ht-zf9">Product overview</a>|
 |HT-Z9F|3.1 channel Dolby Atmos/DTS:X soundbar with Wi-Fi/Bluetooth technology|<a href="https://www.sony.com/electronics/sound-bars/ht-z9f">Product overview</a>|
 |HT-CT800|2.1 channel soundbar with Wi-Fi/Bluetooth technology||
+|HT-790 / HT-S40R\*|Home cinema system with Bluetooth/Wi-Fi technology||
   
 
 ### **Receivers**
@@ -63,6 +64,10 @@ The following Sony audio products are accessible via the Homebridge Sony Audio P
 |DeviceSRS-RA5000|Premium Wireless Speaker with Ambient Room-filling Sound|<a href="https://www.sony.co.uk/electronics/wireless-speakers/srs-ra5000" target="_blank">Product information</a>|
 |SRS-RA3000|Premium Wireless Speaker with Ambient Room-filling Sound|<a href="https://www.sony.co.uk/electronics/wireless-speakers/srs-ra3000" target="_blank">Product information</a>|
 |SRS-ZR5|Portable Wireless Bluetooth/Wi-Fi speaker"|
+
+\* Reported as working by users, not verified by the maintainers.
+Any device that answers the Sony Audio Control API and reports the
+`homeTheaterSystem` or `personalAudio` product category should work.
 
 ## Installation
 If you are new to homebridge, please first read the homebridge [documentation](https://www.npmjs.com/package/homebridge).
@@ -112,4 +117,34 @@ Finded devices will be publishing externally, so you need paired it seperately:
 2. Click "I Don't Have a code or Cannot Scan"
 3. On the next screen you find the discovered devices
 4. Tap one and enter the pin code from your homebridge instance.
+
+## Troubleshooting
+
+### "Adding new accessory" is logged on every Homebridge restart
+This is expected. The accessory is a Television accessory, which HomeKit requires to be
+published as an *external* accessory. Homebridge does not cache external accessories, so
+the plugin re-creates and re-publishes it at every start. The accessory keeps its pairing
+and its HomeKit settings, because its UUID is derived from the (stable) UDN of the device.
+
+### The device disappeared from the Home app / I deleted it and cannot add it back
+External accessories are paired separately from the Homebridge bridge, so after removing
+the accessory in the Home app you have to add it again with the
+[Setting up](#setting-up) steps above ("Add Accessory" → "I Don't Have a Code or Cannot
+Scan" → pick the device → enter the PIN of your Homebridge instance). The accessory only
+shows up there while Homebridge is running and the device has been discovered - check the
+log for `Compatible device found, added: <name>` first. If the Home app still refuses to
+add it, remove the accessory in the Home app once more and restart Homebridge.
+
+### `Incompatible device found, skipped: <name>`
+The device answered the discovery, but the plugin could not initialize it. Enable the
+Homebridge debug log (`homebridge -D`) and restart: the debug output contains the reason
+(unsupported product category, unsupported API version or an API error) plus the raw
+requests and answers of the device. Please attach that debug output when reporting a
+new device.
+
+### The device is not discovered at all
+Discovery relies on SSDP multicast, which does not cross subnets or VLANs. Homebridge and
+the Sony device have to be in the same broadcast domain, and the Homebridge host must not
+block UDP port 1900. Adding the device manually by IP address is not supported: the plugin
+needs the UPnP device description that is only served through the discovery answer.
 

--- a/src/sonyAudioAccessory.ts
+++ b/src/sonyAudioAccessory.ts
@@ -300,6 +300,24 @@ export class SonyAudioAccessory {
   }
 
   /**
+   * Invokes a HAP characteristic callback, swallowing (and logging) any error it throws.
+   *
+   * HAP wraps every callback in `once()`, so a callback that is invoked a second time -
+   * or one that HAP has already answered itself after a timeout - throws
+   * "This callback function has already been called by someone else". Such an exception
+   * must never leak into the promise chain, otherwise the rejection handler would call
+   * the very same callback again and flood the log. See #41, #33, #8.
+   */
+  private invokeCallback(callback: CharacteristicSetCallback | CharacteristicGetCallback,
+    ...args: [(Error | null | undefined)?, CharacteristicValue?]) {
+    try {
+      (callback as (...cbArgs: unknown[]) => void)(...args);
+    } catch (err) {
+      this.platform.log.debug(`The characteristic callback has been already answered: ${err}`);
+    }
+  }
+
+  /**
    * Wrap the CharacteristicSetCallback callback for loggin the error
    * and run heartbeat if the device is not available
    * @param callback 
@@ -310,7 +328,17 @@ export class SonyAudioAccessory {
       // reinit the characteristics because we assume that the connection with the device is lost
       this.initAccessoryCharacteristics();
     }
-    callback(error, value);
+    this.invokeCallback(callback, error, value);
+  }
+
+  /**
+   * Answers a HAP `set` callback when the given device command settles, exactly once.
+   */
+  private answerOnSettled(promise: Promise<unknown>, callback: CharacteristicSetCallback) {
+    promise.then(
+      () => this.callbackWrapper(callback),
+      err => this.callbackWrapper(callback, err),
+    );
   }
 
   onChangeVolume(volume: number) {
@@ -334,7 +362,8 @@ export class SonyAudioAccessory {
     if (terminal) {
       const inputSubtype = this.getInputSubtype(terminal);
       const inputSourceId = this.inputSourceIds.get(inputSubtype);
-      if (inputSourceId) {
+      // the identifier of the first input is 0, so it must not be treated as "not found"
+      if (inputSourceId !== undefined) {
         this.serviceTv.updateCharacteristic(this.platform.Characteristic.ActiveIdentifier, inputSourceId);
         this.platform.log.debug('Set Characteristic ActiveIdentifier -> ', inputSourceId);
       }
@@ -344,43 +373,38 @@ export class SonyAudioAccessory {
   setVolume(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     this.platform.log.debug('Set Characteristic VolumeSelector -> ', value);
     const volumeSelector = value === this.platform.Characteristic.VolumeSelector.INCREMENT ? 0 : 1;
-    this.device.setVolume(volumeSelector)
-      .then(() => this.callbackWrapper(callback))
-      .catch(err => this.callbackWrapper(callback, err));
+    this.answerOnSettled(this.device.setVolume(volumeSelector), callback);
   }
 
   setVolumeAbsolute(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    if (typeof value === 'number') {
-      this.platform.log.debug('Set Characteristic Volume -> ', value);
-      this.device.setVolumeAbsolute(value)
-        .then(() => this.callbackWrapper(callback))
-        .catch(err => this.callbackWrapper(callback, err));
+    if (typeof value !== 'number') {
+      this.callbackWrapper(callback);
+      return;
     }
+    this.platform.log.debug('Set Characteristic Volume -> ', value);
+    this.answerOnSettled(this.device.setVolumeAbsolute(value), callback);
   }
 
   setMute(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     this.platform.log.debug('Set Characteristic Mute -> ', value);
     const mute = !!value;
-    this.device.setMute(mute)
-      .then(() => this.callbackWrapper(callback))
-      .catch(err => this.callbackWrapper(callback, err));
+    this.answerOnSettled(this.device.setMute(mute), callback);
   }
 
   setPower(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     this.platform.log.debug('Set Power Characteristic Active -> ', value);
-    this.device.setPower(value === this.platform.Characteristic.Active.ACTIVE)
-      .then(() => this.callbackWrapper(callback))
-      .catch(err => this.callbackWrapper(callback, err));
+    this.answerOnSettled(this.device.setPower(value === this.platform.Characteristic.Active.ACTIVE), callback);
   }
 
   setSource(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     this.platform.log.debug('Set Characteristic ActiveIdentifier -> ', value);
     const terminal = this.inputSources.get(value as number);
-    if (terminal) {
-      this.device.setSource(terminal)
-        .then(() => this.callbackWrapper(callback))
-        .catch(err => this.callbackWrapper(callback, err));
+    if (!terminal) {
+      // answer anyway, otherwise HomeKit waits for the callback until it times out
+      this.callbackWrapper(callback);
+      return;
     }
+    this.answerOnSettled(this.device.setSource(terminal), callback);
   }
 
   setRemoteKey(value: CharacteristicValue, callback: CharacteristicSetCallback) {
@@ -388,44 +412,28 @@ export class SonyAudioAccessory {
 
     switch (value) {
       case this.platform.Characteristic.RemoteKey.ARROW_UP:
-        this.device.setUp()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setUp(), callback);
         break;
       case this.platform.Characteristic.RemoteKey.ARROW_DOWN:
-        this.device.setDown()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setDown(), callback);
         break;
       case this.platform.Characteristic.RemoteKey.ARROW_RIGHT:
-        this.device.setRigth()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setRigth(), callback);
         break;
       case this.platform.Characteristic.RemoteKey.ARROW_LEFT:
-        this.device.setLeft()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setLeft(), callback);
         break;
       case this.platform.Characteristic.RemoteKey.SELECT:
-        this.device.setSelect()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setSelect(), callback);
         break;
       case this.platform.Characteristic.RemoteKey.BACK:
-        this.device.setBack()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setBack(), callback);
         break;
       case this.platform.Characteristic.RemoteKey.INFORMATION:
-        this.device.setInformation()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setInformation(), callback);
         break;
       case this.platform.Characteristic.RemoteKey.PLAY_PAUSE:
-        this.device.setPause()
-          .then(() => this.callbackWrapper(callback))
-          .catch(err => this.callbackWrapper(callback, err));
+        this.answerOnSettled(this.device.setPause(), callback);
         break;
       default:
         this.callbackWrapper(callback);
@@ -442,30 +450,37 @@ export class SonyAudioAccessory {
     const inputName = getHomeKitName(String(value), 'Input');
     this.platform.log.debug('Set Characteristic InputSource ConfiguredName -> ', inputName);
     this.accessorySettings.setInputName(serviceInputSource.subtype!, inputName)
-      .then(() => callback(null))
-      .catch(err => callback(err));
+      .then(
+        () => this.invokeCallback(callback, null),
+        err => this.invokeCallback(callback, err),
+      );
   }
 
   setInputSourceTargetVisibilityState(serviceInputSource: Service, value: CharacteristicValue, callback: CharacteristicSetCallback) {
     this.platform.log.debug('Set Characteristic InputSource Target Visibility State -> ', value);
     this.accessorySettings.setInputVisibility(serviceInputSource.subtype!, value as 0 | 1)
       .then(inputSettings => serviceInputSource.updateCharacteristic(this.platform.Characteristic.CurrentVisibilityState, inputSettings.visibilityState!))
-      .then(() => callback(null))
-      .catch(err => callback(err));
+      .then(
+        () => this.invokeCallback(callback, null),
+        err => this.invokeCallback(callback, err),
+      );
   }
 
   getInputSourceCurrentVisibilityState(serviceInputSource: Service, callback: CharacteristicGetCallback) {
     this.platform.log.debug('Get Characteristic InputSource Current Visibility State');
     this.accessorySettings.getInputVisibility(serviceInputSource.subtype!, serviceInputSource.getCharacteristic(this.platform.Characteristic.CurrentVisibilityState).value as 0| 1)
-      .then(inputVisibility => callback(null, inputVisibility))
-      .catch(err => callback(err));
-    
+      .then(
+        inputVisibility => this.invokeCallback(callback, null, inputVisibility),
+        err => this.invokeCallback(callback, err),
+      );
   }
 
   getInputSourceTargetVisibilityState(serviceInputSource: Service, callback: CharacteristicGetCallback) {
     this.platform.log.debug('Get Characteristic InputSource Target Visibility State');
     this.accessorySettings.getInputVisibility(serviceInputSource.subtype!, serviceInputSource.getCharacteristic(this.platform.Characteristic.TargetVisibilityState).value as 0| 1)
-      .then(inputVisibility => callback(null, inputVisibility))
-      .catch(err => callback(err));
+      .then(
+        inputVisibility => this.invokeCallback(callback, null, inputVisibility),
+        err => this.invokeCallback(callback, err),
+      );
   }
 }

--- a/src/sonyAudioAccessorySettings.ts
+++ b/src/sonyAudioAccessorySettings.ts
@@ -86,7 +86,7 @@ export class SonyAudioAccessorySettings {
 
   async getInputName(id: string, defaultName: string) {
     let input = this.getInput(id);
-    if (input === undefined || input.visibilityState === undefined) {
+    if (input === undefined || input.name === undefined) {
       input = await this.setInputName(id, defaultName);
     } 
     return input.name!;

--- a/src/sonyDevice.ts
+++ b/src/sonyDevice.ts
@@ -183,6 +183,49 @@ type apiRequest = {
 };
 
 /**
+ * Compares two dotted API versions (`1.2` vs `1.10`) numerically.
+ * Returns a positive number when `a` is newer than `b`.
+ */
+export function compareApiVersions(a: string, b: string): number {
+  const partsA = a.split('.').map(p => Number.parseInt(p, 10) || 0);
+  const partsB = b.split('.').map(p => Number.parseInt(p, 10) || 0);
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const diff = (partsA[i] || 0) - (partsB[i] || 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Negotiates the version of an api method to use with the device.
+ *
+ * Devices answer `getSupportedApiInfo` with *every* version they support, in no
+ * guaranteed order (the 2023 receivers advertise `getSystemInformation` 1.4 and 1.6,
+ * and `getCurrentExternalTerminalsStatus` 1.0 and 1.2). So pick the newest version
+ * the plugin knows about, and if the device speaks none of them, fall back to the
+ * newest version the device advertises instead of declaring the device incompatible.
+ *
+ * @returns the version to use, or `null` if the device does not expose the method at all
+ */
+export function negotiateApiVersion(
+  apisInfo: SonyDeviceApiInfo[] | undefined,
+  service: string,
+  method: string,
+  knownVersions: string[],
+): string | null {
+  const api = apisInfo?.find(a => a.service === service)?.apis?.find(m => m.name === method);
+  const advertised = (api?.versions || []).map(v => v.version).filter(v => typeof v === 'string');
+  if (advertised.length === 0) {
+    return null;
+  }
+  const supported = advertised.filter(v => knownVersions.includes(v));
+  const candidates = supported.length > 0 ? supported : advertised;
+  return candidates.sort(compareApiVersions)[candidates.length - 1];
+}
+
+/**
  * Categories of devices supported by this module
  */
 const COMPATIBLE_DEVICE_CATEGORIES = [
@@ -423,14 +466,10 @@ export class SonyDevice extends EventEmitter {
     if (!this._externalTerminals) {
       // get the terminals info from device
 
-      const serviceApiInfo = this.apisInfo.find(v => v.service === 'avContent');
-      let currentExternalTerminalsVersion: string | null = null;
-    
-      const api = serviceApiInfo?.apis.find(api => api.name === 'getCurrentExternalTerminalsStatus');
-      if (api) {
-        currentExternalTerminalsVersion = api.versions?.[0]?.version || null;
-      }
-   
+      const currentExternalTerminalsVersion = negotiateApiVersion(
+        this.apisInfo, 'avContent', 'getCurrentExternalTerminalsStatus', ['1.0', '1.2'],
+      );
+
       const resTerminals = currentExternalTerminalsVersion === '1.2'
         ? await this.axiosInstance.post('/avContent', JSON.stringify(ApiRequestCurrentExternalTerminalsStatusv1_2))
         : await this.axiosInstance.post('/avContent', JSON.stringify(ApiRequestCurrentExternalTerminalsStatusv1_0));
@@ -591,21 +630,19 @@ export class SonyDevice extends EventEmitter {
     const resApiInfo = await axiosInstance.post('/guide', JSON.stringify(ApiRequestSupportedApiInfo));
     const apisInfo = resApiInfo.data.result[0];
 
-    let systemInformationVersion = null;
+    const service = 'system';
+    const systemInformationVersion = negotiateApiVersion(apisInfo, service, 'getSystemInformation', ['1.4', '1.6']);
 
-    const serviceApiInfo = apisInfo.find(v => v.service === 'system');  
-    const api = serviceApiInfo.apis.find(api => api.name === 'getSystemInformation');
-    if (api) {
-      systemInformationVersion = api.versions?.[0]?.version || null;
-    }
- 
-    const ApiRequestSystemInformation = systemInformationVersion === '1.6' ? ApiRequestSystemInformationv1_6 : ApiRequestSystemInformationv1_4;
+    // `getSystemInformation` takes no parameters in any of its versions, so an unknown
+    // (newer) version advertised by the device can safely be requested as is.
+    const ApiRequestSystemInformation = systemInformationVersion === '1.4' ? ApiRequestSystemInformationv1_4
+      : systemInformationVersion === '1.6' ? ApiRequestSystemInformationv1_6
+        : { ...ApiRequestSystemInformationv1_4, version: systemInformationVersion || '' };
 
     const device = new SonyDevice(baseUrl, upnpUrl, udn, apisInfo, log);
     
     // Gets general system information for the device.
     // check the request for API version compliance
-    const service = 'system';
     if (!device.validateRequest(service, ApiRequestSystemInformation)) {
       throw new UnsupportedVersionApiError(`The specified api version is not supported by the device ${baseUrl.hostname}`);
     }

--- a/tests/platform.spec.ts
+++ b/tests/platform.spec.ts
@@ -152,6 +152,25 @@ describe('publishDevice', () => {
     expect(api.publishExternalAccessories).toHaveBeenCalledTimes(2);
     expect(platform.devices).toHaveLength(2);
   });
+
+  // Television accessories are published as *external* accessories, which homebridge
+  // does not cache: `configureAccessory` is never called for them, so "Adding new
+  // accessory" is logged on every start. That is expected - the accessory keeps its
+  // pairing because the uuid is derived from the (stable) device UDN. See #33.
+  it('re-adds the accessory with the same uuid on every restart (#33)', () => {
+    const device = fakeDevice();
+    platform.publishDevice(device);
+    const firstUuid = api.publishExternalAccessories.mock.calls[0][1][0].UUID;
+
+    // a restart: a brand new platform, homebridge restores nothing for external accessories
+    api = createMockApi();
+    const restarted = new SonyAudioHomebridgePlatform(log, config, api);
+    restarted.publishDevice(fakeDevice());
+
+    expect(restarted.accessories).toHaveLength(0);
+    expect(api.publishExternalAccessories.mock.calls[0][1][0].UUID).toBe(firstUuid);
+    expect(log.info).toHaveBeenCalledWith('Adding new accessory:', 'HT-Z9F');
+  });
 });
 
 describe('discoverDevices', () => {

--- a/tests/sonyAudioAccessory.spec.ts
+++ b/tests/sonyAudioAccessory.spec.ts
@@ -449,6 +449,13 @@ describe('device events', () => {
     device.emit(DEVICE_EVENTS.SOURCE, 'extInput:unknown');
     expect(tvService().getCharacteristic(Characteristic.ActiveIdentifier).value).toBe(1);
   });
+
+  it('updates the active identifier for the first input as well (#42)', async () => {
+    await buildReady();
+    device.emit(DEVICE_EVENTS.SOURCE, 'extInput:hdmi?port=1');
+    device.emit(DEVICE_EVENTS.SOURCE, 'extInput:tv');
+    expect(tvService().getCharacteristic(Characteristic.ActiveIdentifier).value).toBe(0);
+  });
 });
 
 describe('HomeKit set handlers', () => {
@@ -484,11 +491,12 @@ describe('HomeKit set handlers', () => {
     expect(device.setVolumeAbsolute).toHaveBeenCalledWith(42);
   });
 
-  it('ignores a non numeric absolute volume', () => {
+  it('answers HomeKit but skips the device on a non numeric absolute volume', () => {
     const callback = jest.fn();
     sonyAccessory.setVolumeAbsolute('loud' as never, callback);
     expect(device.setVolumeAbsolute).not.toHaveBeenCalled();
-    expect(callback).not.toHaveBeenCalled();
+    // answering is required, otherwise HomeKit waits for the callback until it times out
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 
   it('mutes and unmutes', async () => {
@@ -522,11 +530,11 @@ describe('HomeKit set handlers', () => {
     expect(device.setSource).toHaveBeenCalledWith(TERMINALS[1]);
   });
 
-  it('ignores an unknown input source identifier', () => {
+  it('answers HomeKit but skips the device on an unknown input source identifier', () => {
     const callback = jest.fn();
     sonyAccessory.setSource(99, callback);
     expect(device.setSource).not.toHaveBeenCalled();
-    expect(callback).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 
   const remoteKeys: [number, keyof FakeDevice][] = [
@@ -677,6 +685,73 @@ describe('input source settings handlers', () => {
     await flush();
 
     expect(callback).toHaveBeenCalledWith(error);
+  });
+
+  /**
+   * HAP wraps every characteristic callback in `once()`: calling it twice throws
+   * "This callback function has already been called by someone else". A handler that
+   * chains `.then(cb).catch(cb)` calls it a second time as soon as the first call
+   * throws, which is what flooded the logs in #41 / #33 / #8.
+   */
+  describe('hap callbacks are invoked exactly once (#41)', () => {
+    /** Mimics the HAP `once()` wrapper. */
+    const onceCallback = () => {
+      const calls: any[][] = [];
+      const callback = jest.fn((...args: any[]) => {
+        calls.push(args);
+        if (calls.length > 1) {
+          throw new Error('This callback function has already been called by someone else; it can only be called one time.');
+        }
+        // the very first call throws too, like a HAP characteristic that already timed out
+        throw new Error('This callback function has already been called by someone else; it can only be called one time.');
+      });
+      return { callback, calls };
+    };
+
+    it('does not call the callback again when reading the current visibility throws', async () => {
+      const cb = onceCallback();
+      sonyAccessory.getInputSourceCurrentVisibilityState(inputServices()[0], cb.callback);
+      await flush();
+      expect(cb.callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the callback again when reading the target visibility throws', async () => {
+      const cb = onceCallback();
+      sonyAccessory.getInputSourceTargetVisibilityState(inputServices()[0], cb.callback);
+      await flush();
+      expect(cb.callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the callback again when persisting the visibility throws', async () => {
+      const cb = onceCallback();
+      sonyAccessory.setInputSourceTargetVisibilityState(inputServices()[0], 1, cb.callback);
+      await flush();
+      expect(cb.callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the callback again when persisting a renamed input throws', async () => {
+      const cb = onceCallback();
+      sonyAccessory.setInputSourceConfiguredName(inputServices()[0], 'TV', cb.callback);
+      await flush();
+      expect(cb.callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the callback again when a device command callback throws', async () => {
+      const cb = onceCallback();
+      sonyAccessory.setPower(Characteristic.Active.ACTIVE, cb.callback);
+      await flush();
+      expect(cb.callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the callback again when a failing device command callback throws', async () => {
+      device.setMute = jest.fn(async () => {
+        throw new Error('boom');
+      }) as any;
+      const cb = onceCallback();
+      sonyAccessory.setMute(true, cb.callback);
+      await flush();
+      expect(cb.callback).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/tests/sonyAudioAccessorySettings.spec.ts
+++ b/tests/sonyAudioAccessorySettings.spec.ts
@@ -80,6 +80,14 @@ describe('SonyAudioAccessorySettings', () => {
       expect(await settings.getInputName('tv', 'TV')).toBe('Television');
     });
 
+    it('keeps a custom name that was stored without a visibility state (#42)', async () => {
+      await fs.writeJson(persistFile(), { inputs: [{ id: 'tv', name: 'Television' }] });
+      const settings = await SonyAudioAccessorySettings.GetInstance(UUID, storagePath, log);
+
+      expect(await settings.getInputName('tv', 'TV')).toBe('Television');
+      expect((await fs.readJson(persistFile())).inputs).toEqual([{ id: 'tv', name: 'Television' }]);
+    });
+
     it('does not rewrite the file when the name is unchanged', async () => {
       const settings = await SonyAudioAccessorySettings.GetInstance(UUID, storagePath, log);
       await settings.setInputName('tv', 'TV');

--- a/tests/sonyDevice.spec.ts
+++ b/tests/sonyDevice.spec.ts
@@ -110,12 +110,36 @@ describe('SonyDevice.createDevice', () => {
     await expect(createDevice()).resolves.toBeInstanceOf(SonyDevice);
   });
 
-  it('throws UnsupportedVersionApiError when getSystemInformation version does not match', async () => {
+  it('throws UnsupportedVersionApiError when the device does not advertise getSystemInformation', async () => {
+    const patched = JSON.parse(JSON.stringify(apisInfo));
+    patched[0].apis = patched[0].apis.filter((api: any) => api.name !== 'getSystemInformation');
+    routes.getSupportedApiInfo = { result: [patched] };
+
+    await expect(createDevice()).rejects.toBeInstanceOf(UnsupportedVersionApiError);
+  });
+
+  it('asks for the newest advertised getSystemInformation version (#36, #39, #40)', async () => {
+    // Real devices list every supported version, and not necessarily in order:
+    // the 2023 receivers (STR-AZ5000ES, TA-AN1000) answer 1.4 *and* 1.6.
+    const patched = JSON.parse(JSON.stringify(apisInfo));
+    patched[0].apis[0].versions = [
+      { authLevel: '', protocols: '', version: '1.4' },
+      { authLevel: '', protocols: '', version: '1.6' },
+    ];
+    routes.getSupportedApiInfo = { result: [patched] };
+
+    await createDevice();
+
+    expect(bootstrapAxios().lastCall('getSystemInformation').version).toBe('1.6');
+  });
+
+  it('accepts a device that only advertises a getSystemInformation version unknown to the plugin', async () => {
     const patched = JSON.parse(JSON.stringify(apisInfo));
     patched[0].apis[0].versions = [{ authLevel: '', protocols: '', version: '1.5' }];
     routes.getSupportedApiInfo = { result: [patched] };
 
-    await expect(createDevice()).rejects.toBeInstanceOf(UnsupportedVersionApiError);
+    await expect(createDevice()).resolves.toBeInstanceOf(SonyDevice);
+    expect(bootstrapAxios().lastCall('getSystemInformation').version).toBe('1.5');
   });
 
   it('uses the v1.6 request when the device advertises getSystemInformation 1.6', async () => {
@@ -221,6 +245,22 @@ describe('SonyDevice terminals', () => {
   it('uses the v1.2 request when the device advertises it', async () => {
     const patched = JSON.parse(JSON.stringify(apisInfo));
     patched[2].apis[0].versions = [{ authLevel: '', protocols: '', version: '1.2' }];
+    routes.getSupportedApiInfo = { result: [patched] };
+
+    const device = await createDevice();
+    await device.getExternalTerminals();
+
+    expect(apiAxios().lastCall('getCurrentExternalTerminalsStatus').version).toBe('1.2');
+  });
+
+  it('uses the v1.2 request when the device advertises both 1.0 and 1.2 (#40)', async () => {
+    // The 2023 receivers answer with the full version list; only 1.2 returns
+    // all the inputs, the 1.0 answer is truncated to a couple of sources.
+    const patched = JSON.parse(JSON.stringify(apisInfo));
+    patched[2].apis[0].versions = [
+      { authLevel: '', protocols: '', version: '1.0' },
+      { authLevel: '', protocols: '', version: '1.2' },
+    ];
     routes.getSupportedApiInfo = { result: [patched] };
 
     const device = await createDevice();


### PR DESCRIPTION
Backlog cleanup, each change backed by a test that fails on `master`.

### API version negotiation (#36, #39, #40)
`getSupportedApiInfo` lists **every** version a device supports, in no guaranteed order.
The plugin took `versions[0]`, so a device advertising `getSystemInformation` 1.4 **and** 1.6
could end up requesting a version it does not speak (`Incompatible device found, skipped`),
and a receiver advertising `getCurrentExternalTerminalsStatus` 1.0 **and** 1.2 was queried
with the 1.0 request, which returns a truncated input list on the 2023 receivers.
Now the newest known version is picked, with a fallback to the newest advertised one.

### HAP callbacks are called exactly once (#41, #33, #8)
`promise.then(cb).catch(cb)` calls the callback a second time as soon as the first call throws,
which is exactly what produced
`This callback function has already been called by someone else` at
`sonyAudioAccessory.ts:442/450`. Callback invocation is now guarded and the rejection path is
separated from the fulfilment path. Unknown input identifiers / non numeric volumes are
acknowledged too, instead of leaving HomeKit waiting for a timeout.

### Input handling (#42)
* `ActiveIdentifier` is now updated for the first input as well (identifier `0` was treated as "not found").
* A persisted custom input name is no longer reset to the default when the stored entry has no visibility state.

### Docs (#23, #27, #21, #33, #8)
Troubleshooting section (external accessories are not cached, how to re-pair, SSDP subnet limits,
what to do on `Incompatible device found`) and HT-790 added to the supported soundbars.