### PR TITLE
fix: never leave the accessory without input sources (#42)

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -104,10 +104,13 @@ export class SonyAudioHomebridgePlatform implements DynamicPlatformPlugin {
       // store a copy of the device object in the `accessory.context`
       accessory.context = device;
       // create the accessory handler for the newly create accessory
-      new SonyAudioAccessory(this, accessory);
+      const sonyAudioAccessory = new SonyAudioAccessory(this, accessory);
 
-      // publish external accessories (the accessory has a television service)
-      this.api.publishExternalAccessories(PLUGIN_NAME, [accessory]);
+      // publish external accessories (the accessory has a television service),
+      // but only once the input sources have been created, otherwise HomeKit shows
+      // a television without any input
+      Promise.resolve(sonyAudioAccessory.ready)
+        .then(() => this.api.publishExternalAccessories(PLUGIN_NAME, [accessory]));
     }
 
     // save Sony Device for the next correct shutdown

--- a/src/sonyAudioAccessory.ts
+++ b/src/sonyAudioAccessory.ts
@@ -34,6 +34,15 @@ export class SonyAudioAccessory {
 
   private accessorySettings!: SonyAudioAccessorySettings;
 
+  /**
+   * Resolves as soon as the InputSource services have been built (or their creation
+   * has failed and a retry has been scheduled). The platform waits for it before
+   * publishing the accessory, so HomeKit never sees a Television without inputs.
+   */
+  public readonly ready: Promise<void>;
+
+  private inputsTimeout: NodeJS.Timeout | undefined;
+
   constructor(
     private readonly platform: SonyAudioHomebridgePlatform,
     private readonly accessory: PlatformAccessory<SonyDevice>,
@@ -63,10 +72,7 @@ export class SonyAudioAccessory {
     this.serviceTvSpeaker.setCharacteristic(this.platform.Characteristic.VolumeControlType,
       this.platform.Characteristic.VolumeControlType.ABSOLUTE);
     
-    SonyAudioAccessorySettings.GetInstance(accessory.UUID, platform.api.user.persistPath(), this.platform.log)
-      .then(settings => this.accessorySettings = settings)
-      .then(() => this.device.getInputs())
-      .then(terminals => this.buildInputs(terminals));
+    this.ready = this.initInputs();
 
     // subcribe to events from device
     this.device.on(DEVICE_EVENTS.VOLUME, volume => this.onChangeVolume(volume));
@@ -95,6 +101,32 @@ export class SonyAudioAccessory {
 
     this.serviceTv.addLinkedService(this.serviceTvSpeaker);
 
+  }
+
+  /**
+   * Loads the persisted settings and creates the InputSource services.
+   * A device that is asleep or unreachable at this moment must not leave the accessory
+   * without inputs, so the attempt is repeated until it succeeds. See #42.
+   */
+  private async initInputs(): Promise<void> {
+    if (this.inputsTimeout) {
+      clearTimeout(this.inputsTimeout);
+      this.inputsTimeout = undefined;
+    }
+    try {
+      if (!this.accessorySettings) {
+        this.accessorySettings = await SonyAudioAccessorySettings
+          .GetInstance(this.accessory.UUID, this.platform.api.user.persistPath(), this.platform.log);
+      }
+      const terminals = await this.device.getInputs();
+      await this.buildInputs(terminals);
+    } catch (err) {
+      this.platform.log.error(this.getErrorMessage(err as Error));
+      this.inputsTimeout = setTimeout(() => {
+        this.platform.log.debug(`Device ${this.device.systemInfo.name}: trying to build the inputs again...`);
+        this.initInputs();
+      }, RECONNECT_TIMEOUT);
+    }
   }
 
   /**

--- a/tests/platform.spec.ts
+++ b/tests/platform.spec.ts
@@ -15,7 +15,9 @@ jest.mock('../src/discoverer', () => {
 });
 
 jest.mock('../src/sonyAudioAccessory', () => ({
-  SonyAudioAccessory: jest.fn(),
+  SonyAudioAccessory: jest.fn(function (this: { ready: Promise<void> }) {
+    this.ready = Promise.resolve();
+  }),
 }));
 
 import { Categories, PlatformConfig } from 'homebridge';
@@ -46,6 +48,9 @@ let api: MockApi;
 let platform: SonyAudioHomebridgePlatform;
 
 const discoverer = () => DiscovererMock.instances[DiscovererMock.instances.length - 1];
+
+/** The accessory is published once its inputs are ready, i.e. after a few microtasks. */
+const flushPublish = () => new Promise(resolve => setImmediate(resolve));
 
 beforeEach(() => {
   DiscovererMock.instances.length = 0;
@@ -87,9 +92,10 @@ describe('configureAccessory', () => {
 });
 
 describe('publishDevice', () => {
-  it('publishes a brand new accessory as an external accessory', () => {
+  it('publishes a brand new accessory as an external accessory', async () => {
     const device = fakeDevice();
     platform.publishDevice(device);
+    await flushPublish();
 
     expect(api.publishExternalAccessories).toHaveBeenCalledTimes(1);
     const [pluginName, accessories] = api.publishExternalAccessories.mock.calls[0];
@@ -134,38 +140,61 @@ describe('publishDevice', () => {
     expect(AccessoryMock).not.toHaveBeenCalled();
   });
 
-  it('salts the uuid with HOMEBRIDGE_SONY_AUDIO_DEV', () => {
+  it('salts the uuid with HOMEBRIDGE_SONY_AUDIO_DEV', async () => {
     process.env.HOMEBRIDGE_SONY_AUDIO_DEV = 'dev1';
     const device = fakeDevice();
 
     platform.publishDevice(device);
+    await flushPublish();
 
     const [, accessories] = api.publishExternalAccessories.mock.calls[0];
     expect(accessories[0].UUID).toBe(api.hap.uuid.generate(device.UDN + 'dev1'));
     expect(accessories[0].UUID).not.toBe(api.hap.uuid.generate(device.UDN));
   });
 
-  it('gives different devices different accessories', () => {
+  it('gives different devices different accessories', async () => {
     platform.publishDevice(fakeDevice('uuid:a', 'Bedroom'));
     platform.publishDevice(fakeDevice('uuid:b', 'Kitchen'));
+    await flushPublish();
 
     expect(api.publishExternalAccessories).toHaveBeenCalledTimes(2);
     expect(platform.devices).toHaveLength(2);
+  });
+
+  // The InputSource services are created asynchronously (persisted settings + a device
+  // query), so the accessory must not be published before they exist - otherwise HomeKit
+  // sees a Television without inputs. See #42.
+  it('publishes the accessory only after its inputs have been built (#42)', async () => {
+    let buildInputs!: () => void;
+    AccessoryMock.mockImplementationOnce(function (this: { ready: Promise<void> }) {
+      this.ready = new Promise<void>(resolve => buildInputs = resolve);
+    });
+
+    platform.publishDevice(fakeDevice());
+    await Promise.resolve();
+    expect(api.publishExternalAccessories).not.toHaveBeenCalled();
+
+    buildInputs();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(api.publishExternalAccessories).toHaveBeenCalledTimes(1);
   });
 
   // Television accessories are published as *external* accessories, which homebridge
   // does not cache: `configureAccessory` is never called for them, so "Adding new
   // accessory" is logged on every start. That is expected - the accessory keeps its
   // pairing because the uuid is derived from the (stable) device UDN. See #33.
-  it('re-adds the accessory with the same uuid on every restart (#33)', () => {
+  it('re-adds the accessory with the same uuid on every restart (#33)', async () => {
     const device = fakeDevice();
     platform.publishDevice(device);
+    await flushPublish();
     const firstUuid = api.publishExternalAccessories.mock.calls[0][1][0].UUID;
 
     // a restart: a brand new platform, homebridge restores nothing for external accessories
     api = createMockApi();
     const restarted = new SonyAudioHomebridgePlatform(log, config, api);
     restarted.publishDevice(fakeDevice());
+    await flushPublish();
 
     expect(restarted.accessories).toHaveLength(0);
     expect(api.publishExternalAccessories.mock.calls[0][1][0].UUID).toBe(firstUuid);
@@ -174,11 +203,12 @@ describe('publishDevice', () => {
 });
 
 describe('discoverDevices', () => {
-  it('publishes every device the discoverer finds', () => {
+  it('publishes every device the discoverer finds', async () => {
     api.emit('didFinishLaunching');
     const device = fakeDevice();
 
     discoverer().emit('new-device-found', device);
+    await flushPublish();
 
     expect(api.publishExternalAccessories).toHaveBeenCalledTimes(1);
     expect(platform.devices).toEqual([device]);

--- a/tests/sonyAudioAccessory.spec.ts
+++ b/tests/sonyAudioAccessory.spec.ts
@@ -267,13 +267,41 @@ describe('buildInputs', () => {
       .toBe(Characteristic.TargetVisibilityState.HIDDEN);
   });
 
-  it('marks readonly terminals as not configured', async () => {
-    device.isReadonlyTerminal = jest.fn((terminal: ExternalTerminal) => terminal.uri === 'extInput:tv') as any;
+  it('marks readonly terminals as not configured', async () => {    device.isReadonlyTerminal = jest.fn((terminal: ExternalTerminal) => terminal.uri === 'extInput:tv') as any;
     await buildReady();
     const [tv, hdmi] = inputServices();
 
     expect(tv.getCharacteristic(Characteristic.IsConfigured).value).toBe(Characteristic.IsConfigured.NOT_CONFIGURED);
     expect(hdmi.getCharacteristic(Characteristic.IsConfigured).value).toBe(Characteristic.IsConfigured.CONFIGURED);
+  });
+
+  // A device that is asleep/unreachable while the accessory is being built used to leave
+  // the accessory without any InputSource service - HomeKit then shows the power button
+  // only, until the next Homebridge restart. See #42.
+  it('retries building the inputs when the device does not answer (#42)', async () => {
+    device.getInputs = jest.fn()
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+      .mockResolvedValue(TERMINALS) as any;
+
+    const sonyAccessory = await buildReady();
+    expect(sonyAccessory).toBeDefined();
+    expect(inputServices()).toHaveLength(0);
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining('connect ECONNREFUSED'));
+
+    jest.advanceTimersByTime(5000);
+    await flush();
+    await flush();
+
+    expect(inputServices()).toHaveLength(TERMINALS.length);
+  });
+
+  it('resolves the ready promise even when the inputs cannot be built (#42)', async () => {
+    device.getInputs = jest.fn(async () => {
+      throw new Error('connect ECONNREFUSED');
+    }) as any;
+
+    const sonyAccessory = build();
+    await expect(sonyAccessory.ready).resolves.toBeUndefined();
   });
 
   const inputSourceTypes: [TerminalTypeMeta, number][] = [


### PR DESCRIPTION
`SonyAudioAccessory` built its `InputSource` services in an unguarded promise chain
(`GetInstance().then(getInputs).then(buildInputs)`). If the device was asleep or
unreachable at that moment - which happens regularly right after a Homebridge restart -
the chain rejected silently, no input was ever created and there was no retry, so HomeKit
displayed the Television with the power button only (#42).

* the inputs are now built by a guarded `initInputs()` that logs the failure and retries every 5s
* the accessory exposes a `ready` promise and the platform publishes the external accessory
  only after the inputs exist, so HomeKit never sees a Television without input sources

Both behaviours are covered by tests that fail on `master`.